### PR TITLE
People Page is now CBV

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -7,6 +7,9 @@ class CustomUser(AbstractUser):
     """CustomerUser model describes our sites users"""
     photo = models.ImageField(upload_to='users/%Y/%m/%d/', blank=True)
 
+    class Meta:
+        ordering = ['-id']
+
     def __str__(self):
         return f"{self.first_name} {self.last_name}"
 

--- a/account/tests/test_views.py
+++ b/account/tests/test_views.py
@@ -147,7 +147,7 @@ class ProfileDetailTest(TestCase):
     def test_redirects_if_not_logged_in(self):
         """
         Tests that someone who does not have an account gets redirected
-        when the try and access someones Profile page.
+        to a login when they try and access someone's Profile page.
         """
         response = self.client.get(reverse('user_detail', args=['alfred']))
         self.assertRedirects(response,

--- a/account/urls.py
+++ b/account/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
 
     # Edit Profile
     path('edit/<pk>/', views.EditProfileView.as_view(), name='edit'),
-    path('people/', views.user_list, name='user_list'),
+    path('people/', views.UserListView.as_view(), name='user_list'),
     path('people/<username>/', views.user_detail, name='user_detail'),
 
 ]

--- a/account/views.py
+++ b/account/views.py
@@ -1,9 +1,10 @@
 from django.http import JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import redirect_to_login
 from django.views.decorators.http import require_POST
-from django.views.generic.edit import CreateView, UpdateView
+from django.views.generic import CreateView, UpdateView, ListView
 
 from common.decorators import ajax_required
 from .forms import UserRegistrationForm, UserEditForm
@@ -36,16 +37,16 @@ class EditProfileView(UpdateView):
 
     def user_passes_test(self, request):
         """test to see if the profile belongs to the user"""
-        # Deepsource wantsobject declared in __initi__, which Django does not
-        # like, ignore the warning.
+        # Deepsource wants object declared in __init__, which Django does not
+        # recomend overriding in a view class, ignoring the warning.
         # skipcq: PYL-W0201
         self.object = self.get_object()
         return self.object == request.user
 
     def dispatch(self, request, *args, **kwargs):
         """
-        Overrides  defailt dispatch to force a non-authenticated user to login
-        and to ensure a user who tries to edit a diffrent user's profile gets
+        Overrides default dispatch to force a non-authenticated user to login
+        and to ensure a user who tries to edit a different user's profile gets
         redirected to their own dashboard.
         """
         if request.user.is_authenticated:
@@ -56,10 +57,10 @@ class EditProfileView(UpdateView):
         return redirect_to_login(request.get_full_path())
 
 
-@login_required
-def user_list(request):
-    users = CustomUser.objects.filter(is_active=True)
-    return render(request, 'user/people.html', {'users': users})
+class UserListView(LoginRequiredMixin, ListView):
+    model = CustomUser
+    paginate_by = 25
+    template_name = 'user/people.html'
 
 
 @login_required

--- a/templates/user/people.html
+++ b/templates/user/people.html
@@ -6,7 +6,7 @@
 <h1>People</h1>
 <p>Here is a list of people signed up with PieceView</p>
 <div class="card-deck">
-  {% for user in users %}
+  {% for user in object_list %}
     <div class="card bg-transparent border-warning" style="">
       <img src="{{ user.photo_url }}" class="card-img-top">
       <div class="card-body">


### PR DESCRIPTION
Corrected doc string in test_redirects_if_not_logged_in account/test_views.py.
Added a default order to CustomUser to avoid inconsistent pagination as per Django warning.
Made doc strings in EditProfileView more clear
Converted user_list into a CBV, UserListView. Uses LoginRequiredMixin & has a default paginate of 25 users
adjusted urls.py and people.html template as needed