### PR TITLE
Ajax testing complete

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+  manage.py

--- a/account/views.py
+++ b/account/views.py
@@ -90,10 +90,9 @@ def user_follow(request):
                 Contact.objects.get_or_create(from_user=request.user,
                                               to_user=user)
                 return JsonResponse({'status': 'followed'})
-            else:
-                Contact.objects.filter(from_user=request.user,
-                                       to_user=user).delete()
-                return JsonResponse({'status': 'unfollowed'})
+            Contact.objects.filter(from_user=request.user,
+                                   to_user=user).delete()
+            return JsonResponse({'status': 'unfollowed'})
 
         except CustomUser.DoesNotExist:
             return JsonResponse({'status': 'DoesNotExist'})

--- a/account/views.py
+++ b/account/views.py
@@ -89,12 +89,13 @@ def user_follow(request):
             if action == 'follow':
                 Contact.objects.get_or_create(from_user=request.user,
                                               to_user=user)
+                return JsonResponse({'status': 'followed'})
             else:
                 Contact.objects.filter(from_user=request.user,
                                        to_user=user).delete()
-            return JsonResponse({'status': 'ok'})
+                return JsonResponse({'status': 'unfollowed'})
 
         except CustomUser.DoesNotExist:
-            return JsonResponse({'status': 'ko'})
+            return JsonResponse({'status': 'DoesNotExist'})
 
     return JsonResponse({'status': 'ko'})


### PR DESCRIPTION
Now tests that the follow user view works and only works via ajax with a logged-on user.
added coverage settings file to stop manage.py from showing in coverage results